### PR TITLE
BODA-19 feat: 사이트 하단 푸터 구현

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import '../styles/Footer.css';
+import logo from '../assets/images/boda.png'; // 사이트의 로고 이미지 경로
+
+const Footer = () => {
+  return (
+    <div className="footer">
+      <div className="footerTop">
+        <img src={logo} alt="BODA logo" className="footerLogo" />
+        <span className="footerServiceName">BODA</span>
+      </div>
+      <div className="footerMiddle">
+        <p className='footerText'>© BODA 2024</p>
+        <p className="footerText">카카오테크 부트캠프 24시간이 모자라</p>
+        <p className="footerText">사이트 문의 : acky529@gmail.com</p>
+      </div>
+      <div className="footerBottom">
+        <p className="footerAddress">경기도 성남시 분당구 대왕판교로 660 유스페이스 1 A동 405호</p>
+      </div>
+    </div>
+  );
+};
+
+export default Footer;

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import NavBar from './NavBar';
+import Footer from './Footer';
 
 const Layout = ({ children }) => {
   return (
     <>
       <NavBar />
       <div>{children}</div>
+      <Footer />
     </>
   );
 };

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -6,6 +6,19 @@ const Home = () => {
     <div className="home-container">
       <h1>Welcome to the Main Page</h1>
       <p>This is the main content of the page.</p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
+      <p></p>
     </div>
   );
 };

--- a/src/styles/Footer.css
+++ b/src/styles/Footer.css
@@ -1,0 +1,45 @@
+.footer {
+    background-color: #f2f2f2; /* 연한 회색 배경 */
+    padding: 20px;
+    text-align: center;
+    font-family: Arial, sans-serif;
+  }
+  
+  .footerTop {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-bottom: 10px;
+  }
+  
+  .footerLogo {
+    height: 40px;
+    margin-right: 5px; /* 로고와 서비스 이름 간의 간격 조정 */
+  }
+  
+  .footerServiceName {
+    font-family: 'SBAggroB';
+    font-size: 25px; /* 서비스 이름 크기 증가 */
+    font-weight: lighter;
+    margin-top: 5px; /* 서비스 이름을 조금 내리기 */
+  }
+  
+  .footerMiddle {
+    margin-bottom: 10px;
+  }
+  
+  .footerText {
+    font-size: 14px;
+    color: #555;
+    margin: 5px 0;
+  }
+  
+  .footerBottom {
+    margin-top: 10px;
+  }
+  
+  .footerAddress {
+    font-size: 14px;
+    color: #555;
+  }
+  


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> BODA-19

<br/>

## 📝 작업 내용

> 사이트 하단 푸터 구현
> 사용방법: 아래와 같은 방식으로 Layout으로 감싸서 사용시 내비게이션 바와 푸터가 모두 적용됩니다.
```
<Layout><Home /></Layout>
```

<br/>

## 📷 스크린샷(선택)

> 제 맥북 전체 화면에서 캡처 첨부합니다.
<img width="1512" alt="스크린샷 2024-08-14 오후 6 13 07" src="https://github.com/user-attachments/assets/9f30072e-9910-453f-ae3b-f6b327a614f5">


<br/>

## 💬 리뷰 요구사항(선택)

