### PR TITLE
BODA-47 feat: 로그아웃 기능 구현 및 내비게이션바 상태관리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.7.5",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-kakao-maps-sdk": "^1.1.27",
@@ -5436,6 +5437,31 @@
       "integrity": "sha512-Mr2ZakwQ7XUAjp7pAwQWRhhK8mQQ6JAaNWSjmjxil0R8BPioMtQsTLOolGYkji1rcL++3dCqZA3zWqpT+9Ew6g==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.5.tgz",
+      "integrity": "sha512-fZu86yCo+svH3uqJ/yTdQ0QHpQu5oL+/QE+QPSv6BZSkDAoky9vytxp7u5qk83OJFS3kEBcesWni9WTZAv3tSw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -14664,6 +14690,12 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "axios": "^1.7.5",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-kakao-maps-sdk": "^1.1.27",

--- a/src/components/NavBar.jsx
+++ b/src/components/NavBar.jsx
@@ -1,10 +1,20 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import '../styles/NavBar.css';
 import logo from '../assets/images/boda.png';
+import { useDispatch } from 'react-redux';
+import { loginSuccess, logout } from "../features/auth/authSlice";
+import { getUserInfo } from "../services/userService";
+import { useSelector } from 'react-redux';
 
-const NavBar = () => { // profileImageUrl prop 추가
+const NavBar = () => {
+  const isLoggedIn = useSelector((state) => state.auth.isLoggedIn);
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
 
   const goToMain = () => {
     navigate('/');
@@ -12,11 +22,42 @@ const NavBar = () => { // profileImageUrl prop 추가
 
   const handleLogout = () => {
     console.log('로그아웃');
+    const backendUrl = process.env.REACT_APP_BACKEND_URL;
+    window.location.href = `${backendUrl}/logout`;
+    dispatch(logout());
+    navigate("/")
+  };
+
+  const goToLoginPage = () => {
+    navigate('/login');
   };
 
   const goToMyPage = () => {
     navigate('/mypage');
   };
+
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      navigate("/");
+      return;
+    }
+    const fetchUserData = async () => {
+      try {
+        const userData = await getUserInfo();
+        setUser(userData);
+        console.info(userData)
+      } catch (err) {
+        setError("사용자 정보를 가져오는 중 오류가 발생했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUserData();
+  }, [isLoggedIn, navigate]);
+
+  
 
   return (
     <div>
@@ -25,13 +66,20 @@ const NavBar = () => { // profileImageUrl prop 추가
         <img src={logo} alt="BODA logo" className="logo" />
         <span className="serviceName">BODA</span>
       </div>
+      {isLoggedIn && user ? (
       <div className="rightSection">
         <div className="profileSection" onClick={goToMyPage}>
           <img src="http://t1.kakaocdn.net/account_images/default_profile.jpeg.twg.thumb.R640x640" alt="Profile" className="profileImage" /> {/* profileImageUrl 사용 */}
-          <span className="userName">은학</span>
+          <span className="userName">{user.nickname}</span>
         </div>
         <span className="logoutText" onClick={handleLogout}>LOGOUT</span>
-      </div>
+      </div> 
+      ):(
+      <div className="rightSection">
+        <span className="logoutText" onClick={goToLoginPage}>LOGIN</span> 
+      </div> 
+      )}
+
       <div className="separator" />
     </div>
     <div className="body-content">

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -16,23 +16,7 @@ const LoginPage = () => {
 
     //백엔드에서 제공하는 카카오 로그인 URL로 리다이렉트 
     window.location.href = `${backendUrl}/oauth2/authorization/kakao`;
-    //dispatch(loginSuccess(true));
-  };
-
-  useEffect(() => {
-    if (isLoggedIn) {
-      navigate('/');
-    }
-  }, [isLoggedIn, navigate]);
-
-  const handleKakaoLogout = () => {
-    const BASE_URL = import.meta.env.VITE_BASE_URL;
-    window.location.href = `${BASE_URL}/v1/logout/kakao`;
-
-    // Redux 상태 업데이트 및 로그아웃 처리
-    dispatch(logout());
-    alert("로그아웃 되었습니다.");
-    navigate("/");
+    dispatch(loginSuccess());
   };
 
   return (

--- a/src/pages/RegisterPage.jsx
+++ b/src/pages/RegisterPage.jsx
@@ -28,7 +28,7 @@ const RegisterPage = () => {
       });
       if (response.ok) {
         console.log('추가 정보가 성공적으로 제출되었습니다.');
-        dispatch(loginSuccess());
+        //dispatch(loginSuccess());
         navigate('/');
       } else {
         console.error('추가 정보 제출에 실패했습니다.');

--- a/src/services/userService.js
+++ b/src/services/userService.js
@@ -1,0 +1,17 @@
+import axios from "axios";
+
+const backendUrl = process.env.REACT_APP_BACKEND_URL;
+
+
+export const getUserInfo = async () => {
+
+  try {
+    const response = await axios.get(`${backendUrl}/api/v1/user`, {
+      withCredentials: true,
+    });
+    return response.data;
+  } catch (error) {
+    console.error("사용자 정보를 가져오는 중 오류가 발생했습니다.", error);
+    throw error;
+  }
+};

--- a/src/styles/NavBar.css
+++ b/src/styles/NavBar.css
@@ -62,7 +62,8 @@
 
 .logoutText {
   font-size: 16px; /* 로그아웃 텍스트 크기 */
-  font-weight: bold;
+  font-weight: 600;
+  /* font-weight: bold; */
   cursor: pointer;
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #BODA-47

<br/>

## 📝 작업 내용

> 로그아웃 기능을 구현하고, 로그인과 로그아웃에 따른 내비게이션 상태를 관리하도록 하였습니다.
> 내비게이션 오른쪽 회원 닉네임과 LOGIN, LOGOUT글자 굵기를 100정도 낮췄습니다.

<br/>

## 📷 스크린샷(선택)

> 로그인의 경우
<img width="1512" alt="스크린샷 2024-08-26 오후 11 30 07" src="https://github.com/user-attachments/assets/bb1a2f01-56d6-48fa-b93e-ddd9322fb2f5">

> 로그아웃의 경우
<img width="1512" alt="스크린샷 2024-08-26 오후 11 31 44" src="https://github.com/user-attachments/assets/75552cee-9a42-4400-ad50-692051a34ff6">

<br/>

## 💬 리뷰 요구사항(선택)

> 내비게이션에서 사용자의 정보를 띄우기 위해 내비게이션이 있는 모든 페이지에서 백엔드로 요청을 보냅니다. 
> 이렇게 구현해도 될까요? 권장하는 방법을 알고 계시나요?
> 그리고 저번 회의때 말씀드렸던 css 적용 문제 나중에 수정해야될것 같습니다.
