### PR TITLE
BODA-71 feat: 추가정보 입력 페이지의 회원가입 타이틀 스타일 가운데 정렬로 수정

### DIFF
--- a/src/styles/RegisterPage.module.css
+++ b/src/styles/RegisterPage.module.css
@@ -19,6 +19,7 @@
 .registerTitle {
   font-size: 24px;
   margin-bottom: 10px;
+  text-align: center;
   font-weight: bold;
 }
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #BODA-71

<br/>

## 📝 작업 내용

> 추가정보 입력 페이지의 "회원가입" 타이틀 문구 스타일을 왼쪽에서 가운데 정렬로 수정하였습니다.

<br/>

## 📷 스크린샷(선택)

> 이미지가 있다면 첨부해주세요

<br/>

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
> 
